### PR TITLE
API change to be more idiomatic Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-goulash/notify
-==============
+Schnouki/notify
+===============
 
-[![GoDoc](https://godoc.org/github.com/goulash/notify?status.png)](https://godoc.org/github.com/goulash/notify)
+[![GoDoc](https://godoc.org/github.com/Schnouki/notify?status.png)](https://godoc.org/github.com/Schnouki/notify)
 
 Package notify provides DBus notifications as specified in the
 [Freedesktop Notifications Specification](https://developer.gnome.org/notification-spec/).

--- a/connection.go
+++ b/connection.go
@@ -7,7 +7,7 @@ package notify
 import (
 	"errors"
 
-	"github.com/guelfey/go.dbus"
+	"github.com/godbus/dbus"
 )
 
 // connection is a global D-Bus connection. TODO: I do not know if this

--- a/notification.go
+++ b/notification.go
@@ -7,7 +7,7 @@ package notify
 import (
 	"time"
 
-	"github.com/guelfey/go.dbus"
+	"github.com/godbus/dbus"
 )
 
 // NotificationUrgency can be either LowUrgency, NormalUrgency, and CriticalUrgency.

--- a/notification.go
+++ b/notification.go
@@ -36,8 +36,8 @@ func (u NotificationUrgency) asHint() map[string]dbus.Variant {
 //	func main() {
 //		critical := notify.New("prog", "", "", "critical-icon.png", time.Duration(0), notify.CriticalUrgency)
 //		boring := notify.New("prog", "", "", "low-icon.png", 1 * time.Second, notify.LowUrgency)
-//		boring.ReaceMsg("Nothing is happening... boring!", "")
-//		critical.RemplaceMsg("Your computer is on fire!", "Here is what you should do:\n ...")
+//		boring.ReplaceMsg("Nothing is happening... boring!", "")
+//		critical.ReplaceMsg("Your computer is on fire!", "Here is what you should do:\n ...")
 //	}
 //
 type Notification struct {

--- a/notify.go
+++ b/notify.go
@@ -93,14 +93,14 @@ func SetUrgency(urgency NotificationUrgency) { note.Urgency = urgency }
 // notification ID and an error, possibly nil. It takes all other values from
 // the implicit notification object.
 func SendMsg(summary, body string) (id uint32, err error) {
-	return note.SendMsg(summary, body)
+	return SendUrgentMsg(summary, body, note.Urgency)
 }
 
 // SendUrgentMsg sends the summary and the body as a notification with the
 // urgency of urgency, and returns a unique notification ID and an error,
 // possibly nil. Otherwise it is like SendMsg.
 func SendUrgentMsg(summary, body string, urgency NotificationUrgency) (id uint32, err error) {
-	return note.SendUrgentMsg(summary, body, urgency)
+	return notify(note.Name, summary, body, note.IconPath, 0, nil, urgency.asHint(), note.timeoutInMS())
 }
 
 // ReplaceMsg replaces the already existing notification with the ID id with
@@ -111,12 +111,12 @@ func SendUrgentMsg(summary, body string, urgency NotificationUrgency) (id uint32
 // such as another urgency, these are also replaced by the defaults in the
 // implicit notification!
 func ReplaceMsg(id uint32, summary, body string) (newID uint32, err error) {
-	return note.ReplaceMsg(id, summary, body)
+	return ReplaceUrgentMsg(id, summary, body, note.Urgency)
 }
 
 // ReplaceUrgentMsg replaces the already existing notification with the ID id
 // with summary and body and urgency, returning the new ID and an error if it
 // fails. It takes all other values from the implicit notification object.
 func ReplaceUrgentMsg(id uint32, summary, body string, urgency NotificationUrgency) (newID uint32, err error) {
-	return note.ReplaceUrgentMsg(id, summary, body, urgency)
+	return notify(note.Name, summary, body, note.IconPath, id, nil, urgency.asHint(), note.timeoutInMS())
 }


### PR DESCRIPTION
Hi there,

Thanks a lot for this package, it works great!
However a few things bother me with the API, especially that IDs must be handled by the user. While this is OK for the "low-level" API (the `SendMsg` and `ReplaceMsg` functions), it's not what I expect when using a `Notification` struct and its methods. More specifically, when I use `n.ReplaceMsg`, I expect it to replace the notification previously displayed with `n` without having to explicitly set its ID and save its new ID.
This PR implements just this: an update of the `Notification` API, without touching to the API that uses the "implicit notification".

Even if it's too much change, the first commit makes sense IMO: it switches to github.com/godbus/dbus instead of github.com/guelfey/go.dbus, which seems unmaintained.
